### PR TITLE
feat: custom android app and activity for inappbrowser handling

### DIFF
--- a/App_Resources/Android/app.gradle
+++ b/App_Resources/Android/app.gradle
@@ -4,13 +4,13 @@ dependencies {
 }
 
 android {
-  compileSdkVersion 33
-  buildToolsVersion "33"
+  compileSdkVersion 34
+  buildToolsVersion "34"
   // ndkVersion ""
 
   defaultConfig {
     minSdkVersion 23
-    targetSdkVersion 33
+    targetSdkVersion 34
 
     // Version Information
     versionCode 1

--- a/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/App_Resources/Android/src/main/AndroidManifest.xml
@@ -1,41 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-	package="__PACKAGE__">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="__PACKAGE__">
 
-	<supports-screens
-		android:smallScreens="true"
-		android:normalScreens="true"
-		android:largeScreens="true"
-		android:xlargeScreens="true"/>
+	<supports-screens android:smallScreens="true" android:normalScreens="true" android:largeScreens="true" android:xlargeScreens="true"/>
 
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
-	<application
-		android:name="com.tns.NativeScriptApplication"
-		android:allowBackup="true"
-		android:icon="@mipmap/ic_launcher"
-		android:label="@string/app_name"
-		android:theme="@style/AppTheme"
-		android:hardwareAccelerated="true">
+	<application android:name="org.nativescript.custom.Application" android:allowBackup="true" android:icon="@mipmap/ic_launcher" android:label="@string/app_name" android:theme="@style/AppTheme" android:hardwareAccelerated="true">
 
-		<activity
-			android:name="com.tns.NativeScriptActivity"
-			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
-			android:theme="@style/LaunchScreenTheme"
-			android:hardwareAccelerated="true"
-      		android:launchMode="singleTask"
-			android:exported="true">
+		<activity android:name="org.nativescript.custom.LaunchActivity" android:exported="true">
+			<intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+				<category android:name="android.intent.category.LAUNCHER" />
+				<action android:name="android.intent.action.VIEW"/>
+				<category android:name="android.intent.category.DEFAULT"/>
+				<category android:name="android.intent.category.BROWSABLE"/>
+			</intent-filter>
+		</activity>
+
+		<activity android:name="org.nativescript.custom.CustomActivity" android:label="@string/title_activity_kimera" android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode" android:theme="@style/LaunchScreenTheme" android:hardwareAccelerated="true" android:launchMode="singleTask" android:exported="true">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />
 
 			<intent-filter>
-				<action android:name="android.intent.action.MAIN" />
-				<category android:name="android.intent.category.LAUNCHER" />
+				<action android:name="android.intent.action.VIEW"/>
+				<category android:name="android.intent.category.DEFAULT"/>
+				<category android:name="android.intent.category.BROWSABLE"/>
 			</intent-filter>
+
 		</activity>
 		<activity android:name="com.tns.ErrorReportActivity"/>
 	</application>

--- a/app/activity.android.ts
+++ b/app/activity.android.ts
@@ -1,0 +1,114 @@
+import {
+  Application,
+  setActivityCallbacks,
+  AndroidActivityCallbacks,
+} from "@nativescript/core";
+
+// Custom Activity which tracks running activities
+// ref: https://github.com/proyecto26/react-native-inappbrowser/issues/213#issuecomment-878915862
+@NativeClass()
+@JavaProxy("org.nativescript.custom.CustomActivity")
+class CustomActivity extends androidx.appcompat.app.AppCompatActivity {
+  public isNativeScriptActivity: boolean;
+
+  private _callbacks: AndroidActivityCallbacks;
+
+  public onCreate(savedInstanceState: android.os.Bundle): void {
+    Application.android.init(this.getApplication());
+    this.isNativeScriptActivity = true;
+    if (!this._callbacks) {
+      setActivityCallbacks(this);
+    }
+
+    this._callbacks.onCreate(
+      this,
+      savedInstanceState,
+      this.getIntent(),
+      super.onCreate
+    );
+
+    (this.getApplication() as any).addActivityToStack(this.getClass());
+  }
+
+  public onNewIntent(intent: android.content.Intent): void {
+    this._callbacks.onNewIntent(
+      this,
+      intent,
+      super.setIntent,
+      super.onNewIntent
+    );
+  }
+
+  public onSaveInstanceState(outState: android.os.Bundle): void {
+    this._callbacks.onSaveInstanceState(
+      this,
+      outState,
+      super.onSaveInstanceState
+    );
+  }
+
+  public onStart(): void {
+    this._callbacks.onStart(this, super.onStart);
+  }
+
+  public onStop(): void {
+    this._callbacks.onStop(this, super.onStop);
+  }
+
+  public onDestroy(): void {
+    this._callbacks.onDestroy(this, super.onDestroy);
+    (this.getApplication() as any).removeActivityFromStack(this.getClass());
+  }
+
+  public onPostResume(): void {
+    this._callbacks.onPostResume(this, super.onPostResume);
+  }
+
+  public onBackPressed(): void {
+    this._callbacks.onBackPressed(this, super.onBackPressed);
+  }
+
+  public onRequestPermissionsResult(
+    requestCode: number,
+    permissions: Array<string>,
+    grantResults: Array<number>
+  ): void {
+    this._callbacks.onRequestPermissionsResult(
+      this,
+      requestCode,
+      permissions,
+      grantResults,
+      undefined /*TODO: Enable if needed*/
+    );
+  }
+
+  public onActivityResult(
+    requestCode: number,
+    resultCode: number,
+    data: android.content.Intent
+  ): void {
+    this._callbacks.onActivityResult(
+      this,
+      requestCode,
+      resultCode,
+      data,
+      super.onActivityResult
+    );
+  }
+}
+
+@NativeClass()
+@JavaProxy("org.nativescript.custom.LaunchActivity")
+class LaunchActivity extends androidx.appcompat.app.AppCompatActivity {
+  public onCreate(savedInstanceState: android.os.Bundle): void {
+    super.onCreate(savedInstanceState);
+
+    const application: any = this.getApplication();
+    // check that MainActivity is not started yet
+    if (!application.isActivityInBackStack(CustomActivity.class)) {
+      const intent = new android.content.Intent(this, CustomActivity.class);
+      this.startActivity(intent);
+    }
+    this.finish();
+  }
+}

--- a/app/app.ts
+++ b/app/app.ts
@@ -1,33 +1,36 @@
-import Vue from 'nativescript-vue'
-import Home from './components/Home.vue'
+import Vue from "nativescript-vue";
+import { InAppBrowser } from "nativescript-inappbrowser";
+import Home from "./components/Home.vue";
 
 declare let __DEV__: boolean;
 
 // Prints Vue logs when --env.production is *NOT* set while building
-Vue.config.silent = !__DEV__
+Vue.config.silent = !__DEV__;
 
 new Vue({
-  render: (h) => h('frame', [h(Home)]),
-}).$start()
+  render: (h) => h("frame", [h(Home)]),
+}).$start();
 
-import { InAppBrowser } from 'nativescript-inappbrowser';
-
-let browser;
 setTimeout(() => {
-  browser = InAppBrowser.openAuth("https://google.com", "https://docs.nativescript.org/", {
-    // iOS Properties
-    dismissButtonStyle: 'cancel',
-    preferredBarTintColor: '#006432',
-    preferredControlTintColor: '#006432',
-    ephemeralWebSession: true,
-    // Android Properties
-    showTitle: false,
-    toolbarColor: '#006432',
-    secondaryToolbarColor: '#006432',
-    navigationBarColor: '#000000',
-    navigationBarDividerColor: '#000000',
-    hasBackButton: true,
-    enableUrlBarHiding: true,
-    enableDefaultShare: false
-  });
+  InAppBrowser.openAuth(
+    "https://docs.nativescript.org/",
+    "https://nativescript.org",
+    {
+      // iOS Properties
+      dismissButtonStyle: "cancel",
+      preferredBarTintColor: "#006432",
+      preferredControlTintColor: "#006432",
+      ephemeralWebSession: true,
+      // Android Properties
+      showInRecents: true,
+      showTitle: false,
+      toolbarColor: "#006432",
+      secondaryToolbarColor: "#006432",
+      navigationBarColor: "#000000",
+      navigationBarDividerColor: "#000000",
+      hasBackButton: true,
+      enableUrlBarHiding: true,
+      enableDefaultShare: false,
+    }
+  );
 }, 1000);

--- a/app/application.android.ts
+++ b/app/application.android.ts
@@ -1,0 +1,28 @@
+let runningActivities = [];
+
+// Custom Application which tracks running activities
+// ref: https://github.com/proyecto26/react-native-inappbrowser/issues/213#issuecomment-878915862
+@NativeClass()
+@JavaProxy("org.nativescript.custom.Application")
+class Application extends android.app.Application {
+  public onCreate(): void {
+    super.onCreate();
+  }
+
+  public attachBaseContext(baseContext: android.content.Context) {
+    super.attachBaseContext(baseContext);
+  }
+
+  public addActivityToStack(cls) {
+    if (!runningActivities.includes(cls)) runningActivities.push(cls);
+  }
+
+  public removeActivityFromStack(cls) {
+    const index = runningActivities.findIndex((c) => c == cls);
+    if (index > -1) runningActivities.splice(index, 1);
+  }
+
+  public isActivityInBackStack(cls) {
+    return runningActivities.includes(cls);
+  }
+}

--- a/app/components/Home.vue
+++ b/app/components/Home.vue
@@ -1,14 +1,14 @@
 <template>
   <Page>
     <ActionBar>
-      <Label text="Home"/>
+      <Label text="Home" />
     </ActionBar>
 
     <GridLayout>
       <Label class="info">
         <FormattedString>
-          <Span class="fas" text.decode="&#xf135; "/>
-          <Span :text="message"/>
+          <Span class="fas" text.decode="&#xf135; " />
+          <Span :text="message" />
         </FormattedString>
       </Label>
     </GridLayout>
@@ -16,28 +16,28 @@
 </template>
 
 <script lang="ts">
-  import Vue from "nativescript-vue";
+import Vue from "nativescript-vue";
 
-  export default Vue.extend({
-    computed: {
-      message() {
-        return "Blank {N}-Vue app";
-      }
-    }
-  });
+export default Vue.extend({
+  computed: {
+    message() {
+      return "Blank {N}-Vue app";
+    },
+  },
+});
 </script>
 
 <style scoped lang="scss">
-  @import '@nativescript/theme/scss/variables/blue';
+@import "@nativescript/theme/scss/variables/blue";
 
-  // Custom styles
-  .fas {
-    @include colorize($color: accent);
-  }
+// Custom styles
+.fas {
+  @include colorize($color: accent);
+}
 
-  .info {
-    font-size: 20;
-    horizontal-align: center;
-    vertical-align: center;
-  }
+.info {
+  font-size: 20;
+  horizontal-align: center;
+  vertical-align: center;
+}
 </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "nativescript-vue": "~2.9.3"
       },
       "devDependencies": {
-        "@nativescript/android": "8.6.2",
+        "@nativescript/android": "~8.6.2",
         "@nativescript/types": "~8.6.0",
         "@nativescript/webpack": "~5.0.18",
         "@types/node": "~17.0.21",
@@ -1628,16 +1628,16 @@
       }
     },
     "node_modules/css-loader": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.9.0.tgz",
-      "integrity": "sha512-3I5Nu4ytWlHvOP6zItjiHlefBNtrH+oehq8tnQa2kO305qpVyx9XNIT1CXIj5bgCJs7qICBCkgCYxQLKPANoLA==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.9.1.tgz",
+      "integrity": "sha512-OzABOh0+26JKFdMzlK6PY1u5Zx8+Ck7CVRlcGNZoY9qwJjdfu2VWFuprTIpPW+Av5TZTVViYWcFQaEEQURLknQ==",
       "dev": true,
       "dependencies": {
         "icss-utils": "^5.1.0",
-        "postcss": "^8.4.31",
+        "postcss": "^8.4.33",
         "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.3",
-        "postcss-modules-scope": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.4",
+        "postcss-modules-scope": "^3.1.1",
         "postcss-modules-values": "^4.0.0",
         "postcss-value-parser": "^4.2.0",
         "semver": "^7.5.4"
@@ -1831,9 +1831,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.637",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.637.tgz",
-      "integrity": "sha512-G7j3UCOukFtxVO1vWrPQUoDk3kL70mtvjc/DC/k2o7lE0wAdq+Vwp1ipagOow+BH0uVztFysLWbkM/RTIrbK3w==",
+      "version": "1.4.639",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.639.tgz",
+      "integrity": "sha512-CkKf3ZUVZchr+zDpAlNLEEy2NJJ9T64ULWaDgy3THXXlPVPkLu3VOs9Bac44nebVtdwl2geSj6AxTtGDOxoXhg==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3423,9 +3423,9 @@
       }
     },
     "node_modules/postcss-modules-scope": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.0.tgz",
-      "integrity": "sha512-SaIbK8XW+MZbd0xHPf7kdfA/3eOt7vxJ72IRecn3EzuZVLr1r0orzf0MX/pN8m+NMDoo6X/SQd8oeKqGZd8PXg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.1.1.tgz",
+      "integrity": "sha512-uZgqzdTleelWjzJY+Fhti6F3C9iF1JR/dODLs/JDefozYcKTBCdD8BIl6nNPbTbcLnGrk56hzwZC2DaGNvYjzA==",
       "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.4"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "nativescript-vue": "~2.9.3"
   },
   "devDependencies": {
-    "@nativescript/android": "8.6.2",
+    "@nativescript/android": "~8.6.2",
     "@nativescript/types": "~8.6.0",
     "@nativescript/webpack": "~5.0.18",
     "@types/node": "~17.0.21",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "target": "ES2020",
     "module": "esnext",
     "moduleResolution": "node",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,22 @@
 const webpack = require("@nativescript/webpack");
 
 module.exports = (env) => {
-	webpack.init(env);
+  // custom activity handling for android
+  // https://docs.nativescript.org/guide/extending-classes-and-implementing-interfaces-android#custom-android-application-and-activity
+  env.appComponents = (env.appComponents || []).concat([
+    "./app/activity.android",
+  ]);
+  webpack.init(env);
 
-	// Learn how to customize:
-	// https://docs.nativescript.org/webpack
+  // Learn how to customize:
+  // https://docs.nativescript.org/webpack
+  webpack.chainWebpack((config) => {
+    if (webpack.Utils.platform.getPlatformName() === "android") {
+      // custom application
+      // ref: https://docs.nativescript.org/guide/extending-classes-and-implementing-interfaces-android#custom-android-application-and-activity
+      config.entry("application").add("./app/application.android");
+    }
+  });
 
-	return webpack.resolveConfig();
+  return webpack.resolveConfig();
 };


### PR DESCRIPTION
Fixes inappbrowser case where activity would reset upon launch or resume activities.

1. Adds custom Android Application and Main + Launch activity
Referenced from docs:
https://docs.nativescript.org/guide/extending-classes-and-implementing-interfaces-android#custom-android-application-and-activity and from explanation when using singleTask mode:
https://github.com/proyecto26/react-native-inappbrowser/issues/213#issuecomment-878915862
2. Helps track activities when using `singleTask` mode

https://github.com/Intective/inappbrowser-problem/assets/457187/6eeed578-a1ce-4f78-8751-b49861c49b91

